### PR TITLE
Remove explicit NativeDetector build time init

### DIFF
--- a/basic-native-sample/pom.xml
+++ b/basic-native-sample/pom.xml
@@ -110,7 +110,6 @@
 								<buildArg>--no-fallback</buildArg>
 								<buildArg>--install-exit-handlers</buildArg>
 								<buildArg>-H:+PrintAnalysisCallTree</buildArg>
-								<buildArg>--initialize-at-build-time=org.springframework.core.NativeDetector</buildArg>
 							</buildArgs>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
Now handled by spring-projects/spring-framework#28244.